### PR TITLE
2.25.1 Reaction Roles

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: java -jar build/libs/Cashew-2.25-all.jar
+worker: java -jar build/libs/Cashew-2.25.1-all.jar

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A fun Discord bot with lots of cool commands, themed around the visual novel ser
 Right now it's not available to everyone, but that will soon change. You can join one of the servers where Cashew was already added to try it out, such as [Nekord](https://discord.gg/EVcdmJuM). If you want to invite it, DM me on Discord (B1rtek#2383)
 
 ## Running it yourself
-Currently there is no way to run Cashew yourself because there is a bit of code missing that would create crucial tables in the database. That will be fixed soon, and the only requirements to run Cashew will be:
+The only requirements to run Cashew are:
 - Bot with server members and message content intents
 - Discord API key for a bot
 - A Postgres database
@@ -25,13 +25,13 @@ Currently there is no way to run Cashew yourself because there is a bit of code 
 You'll need to set two environment variables:
 - `TOKEN` - your API key
 - `JDBC_DATABASE_URL` - JDBC URL for the postgres database
-After that, create a JAR with the stage task and run the compiled JAR
+After that, create a JAR with the stage task and run the compiled JAR. Or just run it in the IDE, because why not.
 
 ## Support
-If you encounter any issues, you can:
+If you encounter any problems, you can:
 - Contact me on Discord (B1rtek#2383) to tell me about the issue
 - Send a `/feedback` about the issue
-- Open a new issue on github describing the problem
+- Open a new issue describing the problem
 Issues can be used to suggest new features too
 To see what is currently being worked on, see [Cashew's Trello board](https://trello.com/b/R432WEsW/cashew-bot)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A fun Discord bot with lots of cool commands, themed around the visual novel ser
 - `/when` - a system allowing for creation of your own rules, based on triggers such as member reacting to a message, and actions - adding a role to the member who reacted
 - `/reminder` - schedule reminders for yourself
 - `/birthday` - let everyone on the server know that it's your birthday (and make the bot wish you happy birthday too)
+- `/reactionroles` - set up a nice embed where members can obtain roles by reacting
 - Roleplay commands featuring gifs from the Nekopara anime
 - And more (and the list is growing!)
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.birtek.cashew'
-version '2.25'
+version '2.25.1'
 compileJava.options.encoding = 'UTF-8'
 
 
@@ -39,7 +39,7 @@ build.mustRunAfter clean
 
 jar {
     manifest {
-        attributes 'Class-Path': 'build/libs/Cashew-2.25-all.jar', 'Main-Class': 'com.birtek.cashew.Cashew'
+        attributes 'Class-Path': 'build/libs/Cashew-2.25.1-all.jar', 'Main-Class': 'com.birtek.cashew.Cashew'
     }
 }
 
@@ -48,7 +48,7 @@ wrapper {
 }
 
 shadowJar {
-    archiveFileName = "Cashew-2.25-all.jar"
+    archiveFileName = "Cashew-2.25.1-all.jar"
 }
 
 //

--- a/src/com/birtek/cashew/Cashew.java
+++ b/src/com/birtek/cashew/Cashew.java
@@ -46,7 +46,7 @@ public class Cashew {
                 .setCompression(Compression.NONE)
                 .addEventListeners(new Help(), new Clear(), new BestNeko(), new Nekoichi(), new Reactions(), new BoBurnham(), new Scheduler(),
                         new Cuddle(), new Hug(), new Kiss(), new Pat(), new SocialCredit(), new Korwin(), new Inspirobot(), new DadJoke(), new Counting(), new Ping(),
-                        new Kromer(), new Gifts(), new CaseSim(), new Info(), new Birthday(), new Reminder(), new Feedback(), new Poll(), new Roll(), new CmdSet(), new When(), //commands
+                        new Kromer(), new Gifts(), new CaseSim(), new Info(), new Birthday(), new Reminder(), new Feedback(), new Poll(), new Roll(), new CmdSet(), new When(), new ReactionRoles(), //commands
                         new CountingMessageDeletionDetector(), new CountingMessageModificationDetector(), new WhenExecutor(), //events
                         new ReactionsExecutor(), new Counter()) //messagereations
                 .enableIntents(GatewayIntent.GUILD_MEMBERS, GatewayIntent.MESSAGE_CONTENT)
@@ -212,6 +212,30 @@ public class Cashew {
                                         .addOption(ROLE, "targetrole", "Target role for the action"),
                                 new SubcommandData("list", "Displays an interactive list of custom rules set on this server")
                                         .addOption(INTEGER, "page", "Number of the page of the rules to display, by default set to 1", false, false))
+                        .setDefaultPermissions(moderatorPermissions)
+                        .setGuildOnly(true),
+                Commands.slash("reactionroles", "Create an embed from which members can obtain roles by reacting")
+                        .addOption(STRING, "title", "Title of the reaction roles embed")
+                        .addOption(STRING, "role1", "Emote and role mention for the first reaction role, separated by space")
+                        .addOption(STRING, "role2", "Emote and role mention for the second reaction role, separated by space")
+                        .addOption(STRING, "role3", "Emote and role mention for the third reaction role, separated by space")
+                        .addOption(STRING, "role4", "Emote and role mention for the fourth reaction role, separated by space")
+                        .addOption(STRING, "role5", "Emote and role mention for the fifth reaction role, separated by space")
+                        .addOption(STRING, "role6", "Emote and role mention for the sixth reaction role, separated by space")
+                        .addOption(STRING, "role7", "Emote and role mention for the seventh reaction role, separated by space")
+                        .addOption(STRING, "role8", "Emote and role mention for the eighth reaction role, separated by space")
+                        .addOption(STRING, "role9", "Emote and role mention for the ninth reaction role, separated by space")
+                        .addOption(STRING, "role10", "Emote and role mention for the tenth reaction role, separated by space")
+                        .addOption(STRING, "role11", "Emote and role mention for the eleventh reaction role, separated by space")
+                        .addOption(STRING, "role12", "Emote and role mention for the twelfth reaction role, separated by space")
+                        .addOption(STRING, "role13", "Emote and role mention for the thirteenth reaction role, separated by space")
+                        .addOption(STRING, "role14", "Emote and role mention for the fourteenth reaction role, separated by space")
+                        .addOption(STRING, "role15", "Emote and role mention for the fifteenth reaction role, separated by space")
+                        .addOption(STRING, "role16", "Emote and role mention for the sixteenth reaction role, separated by space")
+                        .addOption(STRING, "role17", "Emote and role mention for the seventeenth reaction role, separated by space")
+                        .addOption(STRING, "role18", "Emote and role mention for the eighteenth reaction role, separated by space")
+                        .addOption(STRING, "role19", "Emote and role mention for the nineteenth reaction role, separated by space")
+                        .addOption(STRING, "role20", "Emote and role mention for the twentieth reaction role, separated by space")
                         .setDefaultPermissions(moderatorPermissions)
                         .setGuildOnly(true)
         ).queue();

--- a/src/com/birtek/cashew/Cashew.java
+++ b/src/com/birtek/cashew/Cashew.java
@@ -1,6 +1,7 @@
 package com.birtek.cashew;
 
 import com.birtek.cashew.commands.*;
+import com.birtek.cashew.database.MessageCache;
 import com.birtek.cashew.reactions.CountingMessageDeletionDetector;
 import com.birtek.cashew.reactions.CountingMessageModificationDetector;
 import com.birtek.cashew.reactions.Counter;
@@ -35,9 +36,9 @@ public class Cashew {
     public static ReactionsSettingsManager reactionsSettingsManager;
     public static CommandsSettingsManager commandsSettingsManager;
     public static WhenSettingsManager whenSettingsManager;
+    public static MessageCache messageCache;
     public static final Permission moderatorPermission = Permission.MANAGE_SERVER;
     public static final DefaultMemberPermissions moderatorPermissions = DefaultMemberPermissions.enabledFor(moderatorPermission);
-
 
     public static void main(String[] args) throws LoginException {
         JDA jda = JDABuilder.createDefault(System.getenv().get("TOKEN"))
@@ -248,5 +249,6 @@ public class Cashew {
         reactionsSettingsManager = new ReactionsSettingsManager();
         commandsSettingsManager = new CommandsSettingsManager();
         whenSettingsManager = new WhenSettingsManager();
+        messageCache = new MessageCache();
     }
 }

--- a/src/com/birtek/cashew/commands/Help.java
+++ b/src/com/birtek/cashew/commands/Help.java
@@ -38,6 +38,7 @@ public class Help extends BaseCommand {
             add("pat");
             add("ping");
             add("poll");
+            add("reactionroles");
             add("reactions");
             add("reminder");
             add("roll");
@@ -206,6 +207,13 @@ public class Help extends BaseCommand {
                 specificHelpEmbed.setTitle("Poll");
                 specificHelpEmbed.addField("`/poll <title> <option1> <option2> [option3..10] [timetovote] [unit]`", "Creates a poll. Poll can have between two and ten options inclusive. By default polls have time to vote set to 24 hours, this can be changed by setting the `timetovote` and `unit` options.", false);
             }
+            case "reactionroles" -> {
+                specificHelpEmbed.addField("Works with prefix " + Cashew.COMMAND_PREFIX, "No", true);
+                specificHelpEmbed.addField("Works in DMs", "No", true);
+                specificHelpEmbed.setTitle("Reaction Roles");
+                specificHelpEmbed.setDescription("Create an embed where server members can obtain roles by reacting");
+                specificHelpEmbed.addField("`/reactionroles [title] [role1..20]`", "Creates an embed with the list of obtainable roles. You can set a custom title of the embed if you feel like it. The role fields should be filled with an emote and a @role that will be obtained by reacting with the emote, separated by space, in order emote, role. It's a shortcut for setting up a bunch of WhenRules that would do the same thing, all WhenRules that make this work will be added to the list when this command is successfully executed.", false);
+            }
             case "reactions" -> {
                 specificHelpEmbed.addField("Works with prefix " + Cashew.COMMAND_PREFIX, "No", true);
                 specificHelpEmbed.addField("Works in DMs", "No", true);
@@ -249,7 +257,7 @@ public class Help extends BaseCommand {
                 specificHelpEmbed.addField("Works in DMs", "No", true);
                 specificHelpEmbed.setTitle("When");
                 specificHelpEmbed.setDescription("Custom trigger-action rules system");
-                specificHelpEmbed.addField("`/when when <trigger> <action> [options relevant to the rule]`", "Creates a new rule. All options that need to be set are included in the trigger and action descriptions. The message deletion trigger does not pass information about the user who deleted the message, so certain features such as assigning roles to that user don't work. Reactions currently don't work with custom emotes.", false);
+                specificHelpEmbed.addField("`/when when <trigger> <action> [options relevant to the rule]`", "Creates a new rule. All options that need to be set are included in the trigger and action descriptions. The message deletion trigger does not pass information about the user who deleted the message, so certain features such as assigning roles to that user might not work if the message isn't in message cache anymore (usually that means that the message is older than 1 hour)", false);
                 specificHelpEmbed.addField("`/when list [page]`", "Shows an interactive list of all rules, the list allows for deleting the rules", false);
             }
             default -> {
@@ -267,7 +275,7 @@ public class Help extends BaseCommand {
         helpEmbed.addField("🎭 Roleplay", "`cuddle`, `hug`, `kiss`, `pat`", false);
         helpEmbed.addField("\uD83D\uDD27 Utilities", "`/feedback`, `/reminder`, `/roll`", false);
         helpEmbed.addField("😂 Fun stuff", "`/bestneko`, `/birthday`, `boburnham`, `/casesim`, `/counting`, `dadjoke`, `/gifts`, `insp`, `korwin`, `kromer`, `nekoichi`, `ping`, `/socialcredit`", false);
-        helpEmbed.addField("\uD83D\uDD27 Mod's tools", "`/clear`, `/cmdset`, `/poll`, `/reactions`, `/scheduler`, `/when`", false);
+        helpEmbed.addField("\uD83D\uDD27 Mod's tools", "`/clear`, `/cmdset`, `/poll`, `/reactionroles`, `/reactions`, `/scheduler`, `/when`", false);
         helpEmbed.addField("❓ Help", "To learn more about a specific command, type `/help <command>`. Note that some of the commands only work as slash commands. To get more information about the bot use `/info`", false);
         helpEmbed.setColor(0xffd297);
         return helpEmbed;

--- a/src/com/birtek/cashew/commands/ReactionRoles.java
+++ b/src/com/birtek/cashew/commands/ReactionRoles.java
@@ -1,0 +1,79 @@
+package com.birtek.cashew.commands;
+
+import com.birtek.cashew.Cashew;
+import com.birtek.cashew.database.WhenRule;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.internal.utils.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+public class ReactionRoles extends BaseCommand {
+
+    @Override
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (event.getName().equals("reactionroles")) {
+            if (cantBeExecuted(event, true)) {
+                event.reply("This command is only available to server moderators").setEphemeral(true).queue();
+                return;
+            }
+            // get all roles
+            ArrayList<Pair<String, Role>> reactionRoles = new ArrayList<>();
+            for (int i = 1; i <= 20; i++) {
+                String reactionAndRole = event.getOption("role" + i, null, OptionMapping::getAsString);
+                if (reactionAndRole == null) continue;
+                String[] reactionRoleSplit = reactionAndRole.split("\\s+");
+                int roleIDBegin = reactionRoleSplit[1].indexOf("<@&");
+                if (roleIDBegin == -1) continue;
+                roleIDBegin += 3;
+                String roleID = reactionRoleSplit[1].substring(roleIDBegin, reactionRoleSplit[1].indexOf(">", roleIDBegin));
+                Role targetRole = Objects.requireNonNull(event.getGuild()).getRoleById(roleID);
+                if (targetRole == null) continue;
+                reactionRoles.add(Pair.of(reactionRoleSplit[0], targetRole));
+            }
+            if (reactionRoles.isEmpty()) {
+                event.reply("No valid emotes/roles were chosen!").setEphemeral(true).queue();
+                return;
+            }
+            // create an embed
+            EmbedBuilder reactionRolesEmbed = new EmbedBuilder();
+            String title = event.getOption("title", "You can obtain these roles by reacting to the message", OptionMapping::getAsString);
+            reactionRolesEmbed.setTitle(title);
+            StringBuilder rolesList = new StringBuilder();
+            for (Pair<String, Role> reactionRole : reactionRoles) {
+                rolesList.append(reactionRole.getLeft()).append(" for ").append(reactionRole.getRight().getAsMention()).append('\n');
+            }
+            reactionRolesEmbed.setDescription(rolesList.toString());
+            // send it
+            String[] embedMessageID = new String[1];
+            event.getChannel().sendMessageEmbeds(reactionRolesEmbed.build()).queue(embedMessage -> embedMessageID[0] = embedMessage.getId());
+            // add rules matching the roles
+            for(Pair<String, Role> reactionRole : reactionRoles) {
+                WhenRule ruleAdd = new WhenRule(event.getGuild().getId());
+                ruleAdd.memberReactsTrigger(embedMessageID[0], reactionRole.getLeft());
+                ruleAdd.addRoleAction(reactionRole.getRight().getId());
+                WhenRule ruleRemove = new WhenRule(event.getGuild().getId());
+                ruleRemove.memberRemovesReactionTrigger(embedMessageID[0], reactionRole.getLeft());
+                ruleRemove.removeRoleAction(reactionRole.getRight().getId());
+                if(!Cashew.whenSettingsManager.addWhenRule(event.getGuild().getId(), ruleAdd) || !Cashew.whenSettingsManager.addWhenRule(event.getGuild().getId(), ruleRemove)) {
+                    event.getChannel().retrieveMessageById(embedMessageID[0]).complete().delete().complete();
+                    event.reply("Something went wrong while applying rules").setEphemeral(true).queue();
+                    return;
+                }
+            }
+            // communicate success
+            event.reply("Reaction roles embed created!").setEphemeral(true).queue();
+            // add reactions
+            Message reactionRolesMessage = event.getChannel().retrieveMessageById(embedMessageID[0]).complete();
+            for(Pair<String, Role> reactionRole : reactionRoles) {
+                reactionRolesMessage.addReaction(Emoji.fromFormatted(reactionRole.getLeft())).queue();
+            }
+        }
+    }
+}

--- a/src/com/birtek/cashew/database/BirthdayRemindersDatabase.java
+++ b/src/com/birtek/cashew/database/BirthdayRemindersDatabase.java
@@ -37,6 +37,24 @@ public class BirthdayRemindersDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists birthdayreminders ( _id bigserial constraint idx_16657_birthdayreminders_pkey primary key, message text, dateandtime text, channelid text, serverid text, userid text );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the birthdayreminders table");
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists defaultbirthdayreminderchannels ( _id bigserial constraint idx_16664_defaultbirthdayreminderchannels_pkey primary key, serverid text, channelid text, override bigint );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the defaultbirthdayreminderchannels table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/database/CachedMessage.java
+++ b/src/com/birtek/cashew/database/CachedMessage.java
@@ -1,0 +1,34 @@
+package com.birtek.cashew.database;
+
+import java.time.Instant;
+
+public final class CachedMessage {
+    private final String messageID;
+    private final String userID;
+    private final String content;
+    private final long timestamp;
+
+    public CachedMessage(String messageID, String userID, String content) {
+        this.messageID = messageID;
+        this.userID = userID;
+        this.content = content;
+        this.timestamp = Instant.now().toEpochMilli();
+    }
+
+    public String messageID() {
+        return messageID;
+    }
+
+    public String userID() {
+        return userID;
+    }
+
+    public String content() {
+        return content;
+    }
+
+    public long lastChangeTimestamp() {
+        return timestamp;
+    }
+
+}

--- a/src/com/birtek/cashew/database/CountingDatabase.java
+++ b/src/com/birtek/cashew/database/CountingDatabase.java
@@ -36,6 +36,15 @@ public class CountingDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists counting ( _id bigserial constraint idx_16692_counting_pkey primary key, activity boolean, current bigint, channelid text, userid text, messageid text, typosleft integer );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the counting table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/database/GiftHistoryDatabase.java
+++ b/src/com/birtek/cashew/database/GiftHistoryDatabase.java
@@ -37,6 +37,15 @@ public class GiftHistoryDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists gifthistory ( _id bigserial constraint idx_16711_gifthistory_pkey primary key, serverid text, userid text, giftid bigint, amountgifted bigint, amountreceived bigint, lastgifted bigint );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the gifthistory table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/database/MessageCache.java
+++ b/src/com/birtek/cashew/database/MessageCache.java
@@ -49,9 +49,25 @@ public class MessageCache {
         HashMap<String, CachedMessage> serverMessages = cachingMap.get(serverID);
         if (serverMessages == null) {
             serverMessages = new HashMap<>();
+            cachingMap.put(serverID, serverMessages);
             return null;
         } else {
             return serverMessages.get(messageID);
         }
+    }
+
+    /**
+     * Removes a message from the cache
+     * @param messageID ID of the message to remove from cache
+     * @param serverID ID of the server from which the message came
+     */
+    public void deleteCachedMessage(String messageID, String serverID) {
+        HashMap<String, CachedMessage> serverMessages = cachingMap.get(serverID);
+        if (serverMessages == null) {
+            serverMessages = new HashMap<>();
+        } else {
+            serverMessages.remove(messageID);
+        }
+        cachingMap.put(serverID, serverMessages);
     }
 }

--- a/src/com/birtek/cashew/database/MessageCache.java
+++ b/src/com/birtek/cashew/database/MessageCache.java
@@ -1,0 +1,57 @@
+package com.birtek.cashew.database;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class MessageCache {
+
+    HashMap<String, HashMap<String, CachedMessage>> cachingMap;
+
+    public MessageCache() {
+        cachingMap = new HashMap<>();
+    }
+
+    /**
+     * Adds a new message to the cache and removes all messages older than 1 hour
+     *
+     * @param message  {@link CachedMessage message} to cache
+     * @param serverID ID of the server from which the message came
+     */
+    public void newMessage(CachedMessage message, String serverID) {
+        HashMap<String, CachedMessage> serverMessages = cachingMap.get(serverID);
+        if (serverMessages == null) {
+            serverMessages = new HashMap<>();
+        } else {
+            long currentTimestamp = Instant.now().toEpochMilli();
+            ArrayList<String> toRemove = new ArrayList<>();
+            for (String id : serverMessages.keySet()) {
+                if (currentTimestamp - serverMessages.get(id).lastChangeTimestamp() > 3600000) {
+                    toRemove.add(id);
+                }
+            }
+            for (String id : toRemove) {
+                serverMessages.remove(id);
+            }
+        }
+        serverMessages.put(message.messageID(), message);
+        cachingMap.put(serverID, serverMessages);
+    }
+
+    /**
+     * Gets the cached message with the provided ID
+     *
+     * @param messageID ID of the message to get
+     * @param serverID  ID of the server from which the message is requested
+     * @return the {@link CachedMessage CachedMessage} if it's still in the cache or null if it's not
+     */
+    public CachedMessage getMessage(String messageID, String serverID) {
+        HashMap<String, CachedMessage> serverMessages = cachingMap.get(serverID);
+        if (serverMessages == null) {
+            serverMessages = new HashMap<>();
+            return null;
+        } else {
+            return serverMessages.get(messageID);
+        }
+    }
+}

--- a/src/com/birtek/cashew/database/PollsDatabase.java
+++ b/src/com/birtek/cashew/database/PollsDatabase.java
@@ -37,6 +37,15 @@ public class PollsDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists polls ( _id bigserial constraint idx_16725_polls_pkey primary key, channelid text, messageid text, endtime text );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the polls table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/database/ReactionsSettingsDatabase.java
+++ b/src/com/birtek/cashew/database/ReactionsSettingsDatabase.java
@@ -39,15 +39,6 @@ public class ReactionsSettingsDatabase extends Database {
         }
 
         try {
-            PreparedStatement preparedStatement = databaseConnection.prepareStatement("DROP TABLE IF EXISTS channelactivity");
-            preparedStatement.execute();
-        } catch (SQLException e) {
-            LOGGER.error("Failed to remove the channelactivity table!");
-            e.printStackTrace();
-            System.exit(1);
-        }
-
-        try {
             PreparedStatement preparedStatement = databaseConnection.prepareStatement("CREATE TABLE IF NOT EXISTS reactions(serverid TEXT, settings TEXT)");
             preparedStatement.execute();
         } catch (SQLException e) {

--- a/src/com/birtek/cashew/database/RemindersDatabase.java
+++ b/src/com/birtek/cashew/database/RemindersDatabase.java
@@ -37,6 +37,15 @@ public class RemindersDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists reminders ( _id bigserial constraint idx_16737_reminders_pkey primary key, content text, timedate text, userid text, ping bigint );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the reminders table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/database/ScheduledMessagesDatabase.java
+++ b/src/com/birtek/cashew/database/ScheduledMessagesDatabase.java
@@ -37,6 +37,15 @@ public class ScheduledMessagesDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists scheduledmessages ( _id bigserial constraint idx_16761_scheduledmessages_pkey primary key, messagecontent text, executiontime text, repetitioninterval text, destinationchannelid text, serverid text );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the scheduledmessages table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/database/SocialCreditDatabase.java
+++ b/src/com/birtek/cashew/database/SocialCreditDatabase.java
@@ -35,6 +35,15 @@ public class SocialCreditDatabase extends Database {
             e.printStackTrace();
             System.exit(1);
         }
+
+        try {
+            PreparedStatement preparedStatement = databaseConnection.prepareStatement("create table if not exists socialcredit ( _id bigserial constraint idx_16749_socialcredit_pkey primary key, serverid text, userid text, credit bigint );");
+            preparedStatement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create the socialcredit table");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     /**

--- a/src/com/birtek/cashew/reactions/WhenExecutor.java
+++ b/src/com/birtek/cashew/reactions/WhenExecutor.java
@@ -66,7 +66,7 @@ public class WhenExecutor extends ListenerAdapter {
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 3);
         for (WhenRule rule : rules) {
-            if (event.getMessageId().equals(rule.getSourceMessageID()) && event.getEmoji().getAsReactionCode().equals(rule.getSourceReaction())) {
+            if (event.getMessageId().equals(rule.getSourceMessageID()) && event.getEmoji().getFormatted().equals(rule.getSourceReaction())) {
                 if (rule.getActionType() == 4 || rule.getActionType() == 5) {
                     EmbedBuilder embedToPass = new EmbedBuilder();
                     embedToPass.setTitle("Member reacted with " + rule.getSourceReaction());
@@ -94,7 +94,7 @@ public class WhenExecutor extends ListenerAdapter {
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 4);
         for (WhenRule rule : rules) {
-            if (event.getMessageId().equals(rule.getSourceMessageID()) && event.getEmoji().getAsReactionCode().equals(rule.getSourceReaction())) {
+            if (event.getMessageId().equals(rule.getSourceMessageID()) && event.getEmoji().getFormatted().equals(rule.getSourceReaction())) {
                 if (rule.getActionType() == 4 || rule.getActionType() == 5) {
                     EmbedBuilder embedToPass = new EmbedBuilder();
                     embedToPass.setTitle("Member removed a reaction " + rule.getSourceReaction());

--- a/src/com/birtek/cashew/reactions/WhenExecutor.java
+++ b/src/com/birtek/cashew/reactions/WhenExecutor.java
@@ -22,6 +22,7 @@ public class WhenExecutor extends ListenerAdapter {
      */
     @Override
     public void onGuildMemberJoin(@NotNull GuildMemberJoinEvent event) {
+        if(event.getUser().getId().equals(event.getJDA().getSelfUser().getId())) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 1);
         for (WhenRule rule : rules) {
@@ -42,6 +43,7 @@ public class WhenExecutor extends ListenerAdapter {
      */
     @Override
     public void onGuildMemberRemove(@NotNull GuildMemberRemoveEvent event) {
+        if(event.getUser().getId().equals(event.getJDA().getSelfUser().getId())) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 2);
         for (WhenRule rule : rules) {
@@ -62,6 +64,7 @@ public class WhenExecutor extends ListenerAdapter {
      */
     @Override
     public void onMessageReactionAdd(@NotNull MessageReactionAddEvent event) {
+        if(event.retrieveUser().complete().getId().equals(event.getJDA().getSelfUser().getId())) return;
         if (!event.isFromGuild()) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 3);
@@ -90,6 +93,7 @@ public class WhenExecutor extends ListenerAdapter {
      */
     @Override
     public void onMessageReactionRemove(@NotNull MessageReactionRemoveEvent event) {
+        if(event.retrieveUser().complete().getId().equals(event.getJDA().getSelfUser().getId())) return;
         if (!event.isFromGuild()) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 4);
@@ -99,7 +103,8 @@ public class WhenExecutor extends ListenerAdapter {
                     EmbedBuilder embedToPass = new EmbedBuilder();
                     embedToPass.setTitle("Member removed a reaction " + rule.getSourceReaction());
                     User interactingUser = event.retrieveUser().complete();
-                    String description = interactingUser.getAsMention() + " (" + interactingUser.getId() + ")";                    if (rule.getActionType() != 5) {
+                    String description = interactingUser.getAsMention() + " (" + interactingUser.getId() + ")";
+                    if (rule.getActionType() != 5) {
                         description += ", in server " + event.getGuild().getName();
                     }
                     embedToPass.setDescription(description);
@@ -117,6 +122,7 @@ public class WhenExecutor extends ListenerAdapter {
      */
     @Override
     public void onMessageUpdate(@NotNull MessageUpdateEvent event) {
+        if(event.getAuthor().getId().equals(event.getJDA().getSelfUser().getId())) return;
         if (!event.isFromGuild()) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 5);

--- a/src/com/birtek/cashew/reactions/WhenExecutor.java
+++ b/src/com/birtek/cashew/reactions/WhenExecutor.java
@@ -1,12 +1,14 @@
 package com.birtek.cashew.reactions;
 
 import com.birtek.cashew.Cashew;
+import com.birtek.cashew.database.CachedMessage;
 import com.birtek.cashew.database.WhenRule;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEvent;
@@ -118,6 +120,16 @@ public class WhenExecutor extends ListenerAdapter {
     }
 
     /**
+     * Caches messages for the edition/deletion triggers
+     */
+    @Override
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+        if(!event.isFromGuild()) return;
+        CachedMessage message = new CachedMessage(event.getMessageId(), event.getAuthor().getId(), event.getMessage().getContentRaw());
+        Cashew.messageCache.newMessage(message, event.getGuild().getId());
+    }
+
+    /**
      * Detects the fifth trigger - member editing their message
      */
     @Override
@@ -126,6 +138,7 @@ public class WhenExecutor extends ListenerAdapter {
         if (!event.isFromGuild()) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 5);
+        CachedMessage oldVersion = Cashew.messageCache.getMessage(event.getMessageId(), event.getGuild().getId());
         for (WhenRule rule : rules) {
             if ((rule.getSourceChannelID() == null) || (rule.getSourceChannelID().equals(event.getChannel().getId()))) {
                 if (rule.getActionType() == 4 || rule.getActionType() == 5) {
@@ -133,6 +146,9 @@ public class WhenExecutor extends ListenerAdapter {
                     embedToPass.setTitle("Member edited their message");
                     String description = event.getAuthor().getAsMention() + " (" + event.getAuthor().getId() + "), in " + (rule.getActionType() != 5 ? ("server " + event.getGuild().getName()) + ", " : "") + "<#" + event.getChannel().getId() + ">";
                     embedToPass.setDescription(description);
+                    if(oldVersion != null) {
+                        embedToPass.addField("Old content", oldVersion.content(), false);
+                    }
                     embedToPass.addField("New content", event.getMessage().getContentRaw(), false);
                     embedToPass.addField("Message link", event.getMessage().getJumpUrl(), false);
                     performPassAction(rule, event.getGuild(), embedToPass.build());
@@ -141,6 +157,8 @@ public class WhenExecutor extends ListenerAdapter {
                 }
             }
         }
+        CachedMessage newVersion = new CachedMessage(event.getMessageId(), event.getAuthor().getId(), event.getMessage().getContentRaw());
+        Cashew.messageCache.newMessage(newVersion, event.getGuild().getId());
     }
 
     /**
@@ -151,12 +169,21 @@ public class WhenExecutor extends ListenerAdapter {
         if (!event.isFromGuild()) return;
         String serverID = event.getGuild().getId();
         ArrayList<WhenRule> rules = Cashew.whenSettingsManager.getRulesOfTriggerType(serverID, 6);
+        CachedMessage oldVersion = Cashew.messageCache.getMessage(event.getMessageId(), event.getGuild().getId());
         for (WhenRule rule : rules) {
             if ((rule.getSourceChannelID() == null) || (rule.getSourceChannelID().equals(event.getChannel().getId()))) {
                 if (rule.getActionType() == 4 || rule.getActionType() == 5) {
                     EmbedBuilder embedToPass = new EmbedBuilder();
                     embedToPass.setTitle("A message was deleted");
-                    String description = "In " + (rule.getActionType() != 5 ? ("server " + event.getGuild().getName()) + ", in " : "") + "<#" + event.getChannel().getId() + ">";
+                    String description;
+                    if(oldVersion != null) {
+                        Member author = event.getGuild().retrieveMemberById(oldVersion.userID()).complete();
+                        String authorPart = author != null ? author.getAsMention() + " (" + oldVersion.userID() + ")" : oldVersion.userID();
+                        description = authorPart + ", in " + (rule.getActionType() != 5 ? ("server " + event.getGuild().getName()) + ", " : "") + "<#" + event.getChannel().getId() + ">";
+                        embedToPass.addField("Deleted content", oldVersion.content(), false);
+                    } else {
+                        description = "In " + (rule.getActionType() != 5 ? ("server " + event.getGuild().getName()) + ", in " : "") + "<#" + event.getChannel().getId() + ">";
+                    }
                     embedToPass.setDescription(description);
                     performPassAction(rule, event.getGuild(), embedToPass.build());
                 } else {
@@ -164,6 +191,7 @@ public class WhenExecutor extends ListenerAdapter {
                 }
             }
         }
+        Cashew.messageCache.deleteCachedMessage(event.getMessageId(), event.getGuild().getId());
     }
 
     /**

--- a/src/com/birtek/cashew/reactions/WhenExecutor.java
+++ b/src/com/birtek/cashew/reactions/WhenExecutor.java
@@ -187,7 +187,12 @@ public class WhenExecutor extends ListenerAdapter {
                     embedToPass.setDescription(description);
                     performPassAction(rule, event.getGuild(), embedToPass.build());
                 } else {
-                    performAction(rule, event.getGuild(), null);
+                    User targetUser = null;
+                    if(oldVersion != null) {
+                        Member author = event.getGuild().retrieveMemberById(oldVersion.userID()).complete();
+                        if(author != null) targetUser = author.getUser();
+                    }
+                    performAction(rule, event.getGuild(), targetUser);
                 }
             }
         }


### PR DESCRIPTION
# Update 2.25.1

## New features
- `/reactionroles`
  - A command that creates an embed with a list of roles that you can obtain by reacting to the message with the listed reactions. Note that it'll work only if Cashew can assign roles to users.
## Fixes
- Custom emotes can be used for WhenRules now (and therefore, also in `/reactionroles`)
- WhenRules no longer apply to Cashew (events triggered by the bot won't generate actions)
- Message edition and deletion triggers now use MessageCache to retrieve the original content and the author of the message, as long as it's less than 1 hour old, which allows for useless WhenRules like "when user deletes a message, assign them a role"
- Cashew can now be ran locally - the missing database code is now in place. Requirements can be found in README 
